### PR TITLE
fix: notification location

### DIFF
--- a/app/stylesheets/main.scss
+++ b/app/stylesheets/main.scss
@@ -90,7 +90,7 @@ html {
 
 // Copy token notification
 .auth-copy-notification {
-  position: absolute;
+  position: fixed;
   left: 50%;
   bottom: 20px;
   z-index: 200;

--- a/app/stylesheets/main.scss
+++ b/app/stylesheets/main.scss
@@ -93,7 +93,6 @@ html {
   position: absolute;
   left: 50%;
   bottom: 20px;
-  transform: translateX(-50%);
   z-index: 200;
 
   .sk-panel {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sn-token-vault",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "dist/dist.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
For entries that are > than number that can fit on screen, the copy notification will render either above the view port or halfway up the screen.
This is obviously not the intended behavior.